### PR TITLE
Refactor serve helpers

### DIFF
--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -1,6 +1,7 @@
 package controllers
 
 import (
+	"fmt"
 	"log"
 	"net/http"
 
@@ -13,63 +14,23 @@ import (
 	"github.com/labstack/echo"
 )
 
-// Return201 helper
-func Return201(context echo.Context) error {
-	return context.JSONBlob(http.StatusCreated, []byte(`{"success": true}`))
+// Serve a successful request
+func Serve(context echo.Context, statusCode int) error {
+	return context.JSONBlob(statusCode, []byte(`{"success": true}`))
 }
 
-// Return200 helper
-func Return200(context echo.Context) error {
-	return context.JSONBlob(http.StatusOK, []byte(`{"success": true}`))
-}
-
-// Return400 helper
-func Return400(context echo.Context, err error) error {
+// Serve a request with errors
+func ServeWithError(context echo.Context, statusCode int, err error) error {
 	handleError(err)
-	return Serve400(context)
-}
-
-// Serve400 helper
-func Serve400(context echo.Context) error {
-	return context.JSONBlob(http.StatusBadRequest, []byte(`{"success": false, "errorCode": 400, "errorMessage": "400 bad request"}`))
-}
-
-// Return403 helper
-func Return403(context echo.Context, err error) error {
-	handleError(err)
-	return Serve403(context)
-}
-
-// Serve403 helper
-func Serve403(context echo.Context) error {
-	return context.JSONBlob(http.StatusForbidden, []byte(`{"success": false, "errorCode": 403, "errorMessage": "400 forbidden"}`))
-}
-
-// Return404 helper
-func Return404(context echo.Context, err error) error {
-	handleError(err)
-	return Serve404(context)
-}
-
-// Serve404 helper
-func Serve404(context echo.Context) error {
-	return context.JSONBlob(http.StatusNotFound, []byte(`{"success": false, "errorCode": 404, "errorMessage": "404 page not found"}`))
-}
-
-// Serve405 helper
-func Serve405(context echo.Context) error {
-	return context.JSONBlob(http.StatusMethodNotAllowed, []byte(`{"success": false, "errorCode": 405, "errorMessage": "405 method not allowed"}`))
-}
-
-// Return500 helper
-func Return500(context echo.Context, err error) error {
-	handleError(err)
-	return Serve500(context)
-}
-
-// Serve500 helper
-func Serve500(context echo.Context) error {
-	return context.JSONBlob(http.StatusInternalServerError, []byte(`{"success": false, "errorCode": 500, "errorMessage": "500 internal server error"}`))
+	body := []byte(fmt.Sprintf(`
+		{
+			"success": false,
+			"errorCode": %d,
+			"errorMessage": "%s"
+		}`,
+		statusCode,
+		http.StatusText(statusCode)))
+	return context.JSONBlob(statusCode, body)
 }
 
 // getUser helper

--- a/controllers/users.go
+++ b/controllers/users.go
@@ -23,7 +23,7 @@ func APIUserLogin(context echo.Context) error {
 	user := &models.User{}
 	err := context.Bind(user)
 	if err != nil {
-		return Return500(context, err)
+		return ServeWithError(context, 500, err)
 	}
 
 	// Get authentication data
@@ -56,7 +56,7 @@ func APIUserLogin(context echo.Context) error {
 	// Generate encoded token and send it as response.
 	encodedToken, err := token.SignedString([]byte(config.GetConfig().JWTKey))
 	if err != nil {
-		return Return500(context, err)
+		return ServeWithError(context, 500, err)
 	}
 
 	return context.JSON(http.StatusOK, map[string]interface{}{
@@ -72,7 +72,7 @@ func APIUserRegister(context echo.Context) error {
 	// Attempt to bind request to User struct
 	err := context.Bind(user)
 	if err != nil {
-		return Return500(context, err)
+		return ServeWithError(context, 500, err)
 	}
 
 	user.HashPassword()
@@ -83,17 +83,17 @@ func APIUserRegister(context echo.Context) error {
 	// Validate request
 	err = user.Validate()
 	if err != nil {
-		return Return400(context, err)
+		return ServeWithError(context, 400, err)
 	}
 
 	// Save to database
 	userCollection := models.UserCollection{}
 	_, err = userCollection.Add(user)
 	if err != nil {
-		return Return500(context, err)
+		return ServeWithError(context, 500, err)
 	}
 
-	return Return201(context)
+	return Serve(context, 201)
 }
 
 // APIUserGetAll gets all users
@@ -102,7 +102,7 @@ func APIUserGetAll(context echo.Context) error {
 	err := userCollection.GetAll()
 
 	if err != nil {
-		return Return500(context, err)
+		return ServeWithError(context, 500, err)
 	}
 
 	return context.JSON(http.StatusOK, userCollection)
@@ -114,16 +114,16 @@ func APIUserGetByID(context echo.Context) error {
 
 	id, err := strconv.ParseUint(context.Param("id"), 10, 64)
 	if err != nil {
-		return Return500(context, err)
+		return ServeWithError(context, 500, err)
 	}
 
 	user, err := userCollection.Get(id)
 	if err != nil {
-		return Return500(context, err)
+		return ServeWithError(context, 500, err)
 	}
 
 	if user == nil {
-		return Return404(context, fmt.Errorf("No User found with id %v", id))
+		return ServeWithError(context, 404, fmt.Errorf("No User found with id %v", id))
 	}
 
 	return context.JSON(http.StatusOK, user)
@@ -136,13 +136,13 @@ func APIUserUpdate(context echo.Context) error {
 	// Attempt to bind request to User struct
 	err := context.Bind(user)
 	if err != nil {
-		return Return500(context, err)
+		return ServeWithError(context, 500, err)
 	}
 
 	// Parse out id
 	id, err := strconv.ParseUint(context.Param("id"), 10, 64)
 	if err != nil {
-		return Return500(context, err)
+		return ServeWithError(context, 500, err)
 	}
 	user.ID = id
 
@@ -150,8 +150,8 @@ func APIUserUpdate(context echo.Context) error {
 	userCollection := models.UserCollection{}
 	err = userCollection.Update(user)
 	if err != nil {
-		return Return500(context, err)
+		return ServeWithError(context, 500, err)
 	}
 
-	return Return200(context)
+	return Serve(context, 200)
 }


### PR DESCRIPTION
## Why

`Returnxxx` helpers became very cluttered.

## What

Refactor all `Returnxxx` helpers to use two helpers: `Serve` for successful requests and `ServeWithError` for those that failed.