### PR TITLE
Optimize filter query

### DIFF
--- a/controllers/logs_test.go
+++ b/controllers/logs_test.go
@@ -342,8 +342,8 @@ func TestDelete(t *testing.T) {
 		assert.Equal(t, http.StatusOK, rec.Code)
 		assert.Equal(t, `{"success": true}`, rec.Body.String())
 
-		log, e := logCollection.Get(id)
-		fmt.Println(e)
+		log, err := logCollection.Get(id)
 		assert.Nil(t, log)
+		assert.Error(t, err)
 	}
 }

--- a/models/logs.go
+++ b/models/logs.go
@@ -151,33 +151,32 @@ func (logCollection *LogCollection) GetAllWithFilters(filters map[string]interfa
 
 	query := `
 		WITH filtered_logs AS (
-		  SELECT
-		    unnest(ids) AS id
-		  FROM (
-		    SELECT
-		      array_agg(id) AS ids
-		    FROM logs
-		    WHERE
-					` + where + `
+			SELECT
+				unnest(ids) AS id
+			FROM (
+				SELECT
+					array_agg(id) AS ids
+				FROM logs
+				WHERE ` + where + `
 				GROUP BY date
 				ORDER BY date DESC
-		    OFFSET :page
-		    LIMIT 30
-		  ) AS agg_ids
+				OFFSET :page
+				LIMIT 30
+			) AS agg_ids
 		)
 		SELECT
-		  id,
-		  user_id,
-		  language,
+			id,
+			user_id,
+			language,
 			to_char(date, 'YYYY-MM-DD') AS date,
-		  duration,
-		  activity,
-		  notes
+			duration,
+			activity,
+			notes
 		FROM logs l
 		WHERE EXISTS (
-		  SELECT 1
-		  FROM filtered_logs fl
-		  WHERE fl.id = l.id
+			SELECT 1
+			FROM filtered_logs fl
+			WHERE fl.id = l.id
 		)
 		ORDER BY date DESC, language
 	`

--- a/models/logs.go
+++ b/models/logs.go
@@ -145,35 +145,42 @@ func (logCollection *LogCollection) GetAllWithFilters(filters map[string]interfa
 		}
 	}
 
-	query := `
-		SELECT
-			id,
-			user_id,
-			language,
-			to_char(date, 'YYYY-MM-DD') AS date,
-			duration,
-			activity,
-			notes
-		FROM logs
-		WHERE
-			id IN (
-				SELECT
-					unnest(ids)
-				FROM (
-					SELECT
-						array_agg(id) AS ids
-					FROM logs
-					WHERE
-						` + where + `
-					GROUP BY date
-					ORDER BY date DESC
-					OFFSET :page
-					LIMIT 30
-				) AS filtered_logs
-			)
-	`
+	if _, ok := filters["page"]; !ok {
+		filters["page"] = 0
+	}
 
-	query = query + " ORDER BY date DESC, language"
+	query := `
+		WITH filtered_logs AS (
+		  SELECT
+		    unnest(ids) AS id
+		  FROM (
+		    SELECT
+		      array_agg(id) AS ids
+		    FROM logs
+		    WHERE
+					` + where + `
+				GROUP BY date
+				ORDER BY date DESC
+		    OFFSET :page
+		    LIMIT 30
+		  ) AS agg_ids
+		)
+		SELECT
+		  id,
+		  user_id,
+		  language,
+			to_char(date, 'YYYY-MM-DD') AS date,
+		  duration,
+		  activity,
+		  notes
+		FROM logs l
+		WHERE EXISTS (
+		  SELECT 1
+		  FROM filtered_logs fl
+		  WHERE fl.id = l.id
+		)
+		ORDER BY date DESC, language
+	`
 
 	rows, err := db.NamedQuery(query, filters)
 


### PR DESCRIPTION
# Why

Got the query reviewed by @kanmuri

<details>
<summary>Chatlog</summary>

```
[13:59:26]  <Kanmuri>	Nandemonai: I'm not sure how different Postgres is on this vs. SQL Server, but I always prefer an exists clause over an in clause with a subquery.
[13:59:39]  <Nandemonai>	exists?
[14:00:34]  <Nandemonai>	not familiar with that one
[14:00:45]  <Kanmuri>	The exists statement (statement not clause, sorry) would have a subquery with a where clause that filters it by the value in the outer query that you're matching on in your "in" clause.
[14:01:43]  <Kanmuri>	https://www.postgresql.org/docs/7.4/static/functions-subquery.html
[14:02:17]  <Nandemonai>	hmmm not sure if I can use that in my use case
[14:03:22]  <Kanmuri>	One of the reasons why an EXISTS statement is often more performant is this: "The subquery will generally only be executed far enough to determine whether at least one row is returned, not all the way to completion."
[14:03:22]  <Nandemonai>	basically I have logs with a date field, but I want to page based on 30 dates with existing records
[14:03:54]  <Nandemonai>	but that seemed to be quite a pain in the ass to write in sql
[14:05:30]  <Nandemonai>	paginate*
[14:23:19]  <Kanmuri>	Hmm.... unless I'm misunderstanding how offset and limit are supposed to work, it looks like you're paging the results by 30 dates, not 30 records
[14:24:20]  <Kanmuri>	You're filtering the results, then grouping them by date.
[14:24:50]  <Kanmuri>	Then you're filtering those rows by the limit and offset to page them in groups of 30.
[14:24:55]  <Kanmuri>	*Then* you're ungrouping them.
[14:25:13]  <Nandemonai>	err yea not 30 records, all records by 30 dates indeed
[14:25:29]  <Nandemonai>	(I wanted to avoid having days cut in the middle)
[14:26:55]  <Kanmuri>	What version of Postgres are you using?
[14:27:02]  <Nandemonai>	hmm let me check
[14:27:45]  <Nandemonai>	9.6.3 i think
[14:27:56]  <Nandemonai>	I can however update easily
[14:28:30]  <Kanmuri>	Well, first thing I would suggest is that you take that innermost query and make it a CTE instead.
[14:29:01]  <Kanmuri>	CTE = Common Table Expression, aka. WITH statement
[14:29:16]  <Nandemonai>	ah WITH
[14:29:28]  <Nandemonai>	that way it only executes once, right?
[14:29:55]  <Kanmuri>	Yes, that's one benefit.
[14:31:09]  <Kanmuri>	It also is useful to help you modularize the query because it gives you an intermediate result set that can then be reused in other CTEs and even the main SELECT.
[14:32:11]  <Nandemonai>	with that you mean using that result set inside the IN?
[14:32:25]  <Kanmuri>	Writing up an SQL fiddle right now :)
[14:32:38]  <Nandemonai>	awesome
[14:32:40]  <Nandemonai>	thanks
[14:33:07]  <Nandemonai>	I haven't had much proper feedback on complicated queries like this that would run in production so this really helps :D
[14:33:21]  <Nandemonai>	I've had some for queries in bigquery but that's a bit different
[14:33:57]  <Kanmuri>	I don't have much experience in Postgres specifically, but I do complex SQL in both Oracle and SQL Server on a daily basis in work.
[14:34:12]  <Kanmuri>	Most of that is transferrable :)
[14:34:15]  <Nandemonai>	haha 
[14:34:25]  <Nandemonai>	yeah the stuff I do usually isn't that complex
[14:34:31]  <Nandemonai>	BQ stuff does get complex
[14:34:38]  <Nandemonai>	I actually learned about WITH only like 3 months ago
[14:34:58]  <Nandemonai>	never really thought about using it outside of BQ but it does make sense
[14:35:04]  <Kanmuri>	Do you have the DDL for that logs table?
[14:35:38]  <Kanmuri>	(The CREATE TABLE statement)
[14:35:39]  <Nandemonai>	yeah it's all in the migrations folder
[14:35:42]  <Nandemonai>	lemme pull that up
[14:35:58]  <Nandemonai>	https://github.com/antonve/logger-api/tree/master/migrations/data
[14:36:41]  <Nandemonai>	gotta make activity and language their own table eventually
[14:45:01]  <Kanmuri>	http://sqlfiddle.com/#!17/f22c7/3
[14:45:42]  <Kanmuri>	I didn't put any data in the table, but you can do that in the schema section after all the DDL statements.
[14:46:03]  <Kanmuri>	Well, tables, since you have users and logs
[14:48:21]  <Kanmuri>	There might be a more efficient way to do that CTE, but I can't think of one right now.
[14:48:32]  <Kanmuri>	It's also almost midnight, so I'm heading for bed soon. :)
[14:48:58]  <Nandemonai>	Kanmuri awesome, thanks
[14:49:43]  <Kanmuri>	I usually type all the keyword lower-case, but I tried to do them upper-case for you, but it looks like I missed with "with" statement xD
[14:49:50]  <Kanmuri>	keywords*
[14:50:51]  <Kanmuri>	Oh, and the exists clause too... and the subquery in it.... www
[14:50:53]  <Kanmuri>	Ah well.
[14:51:39]  <Kanmuri>	Nandemonai: Oh, and you are quite welcome, sir. I hope you find that useful.
[14:52:08]  <Nandemonai>	haha thanks
[14:52:22]  <Nandemonai>	style doesn't matter to me much as long as it's kept consistent in the same project
[14:52:28]  <Nandemonai>	this is just a fiddle anyway
[14:52:32] Kanmuri	nods
[14:52:35]  <Nandemonai>	let me export the data
[14:53:14]  <Nandemonai>	I can export to json/csv/xml easily with pgweb but not sql
[14:53:15]  <Nandemonai>	hmm
[14:53:47]  <Kanmuri>	https://stackoverflow.com/questions/12815496/export-specific-rows-from-a-postgresql-table-as-insert-sql-script
[14:54:25]  <Nandemonai>	that helps
[14:54:26]  <Nandemonai>	ty
[14:54:35]  <Kanmuri>	np :)
[15:00:55]  <Nandemonai>	http://sqlfiddle.com/#!17/36485/2
[15:00:58]  <Nandemonai>	seems to work properly
```

</details>

# What

Ended up implementing it as written in the [sql fiddle](http://sqlfiddle.com/#!17/36485/10).