### PR TITLE
Fix connection pooling & leaks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
     docker:
       # specify the version
       - image: circleci/golang:1.11
-      - image: circleci/postgres:9.6.5-alpine-ram
+      - image: circleci/postgres:9.6.10-alpine-ram
         environment:
           POSTGRES_USER: postgres
           POSTGRES_DB: circle_test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
       - image: circleci/golang:1.11
       - image: circleci/postgres:9.6.5-alpine-ram
         environment:
-          POSTGRES_USER: ubuntu
+          POSTGRES_USER: postgres
           POSTGRES_DB: circle_test
           POSTGRES_PASSWORD: ""
 

--- a/config/test.yml.ci
+++ b/config/test.yml.ci
@@ -1,5 +1,5 @@
 JWT_key: thisIsSecretSoChangeThis
-connection_string: user=ubuntu sslmode=disable dbname=
+connection_string: user=postgres sslmode=disable dbname=
 database: circle_test
 debug: true
 migrations_path: migrations/data

--- a/models/datastore.go
+++ b/models/datastore.go
@@ -3,57 +3,78 @@ package models
 import (
 	"database/sql"
 	"log"
-	"github.com/antonve/logger-api/config"
 
-	// sqlx needs the mysql driver
-	_ "github.com/lib/pq"
 	"github.com/jmoiron/sqlx"
+	_ "github.com/lib/pq"
+
+	"github.com/antonve/logger-api/config"
 )
+
+var sqlxDB *sqlx.DB
+var sqlDB *sql.DB
+var sqlxConnection *sqlx.DB
+var sqlConnection *sql.DB
 
 // GetDatabase Returns database connection from pool
 func GetDatabase() *sqlx.DB {
-	db, err := sqlx.Open("postgres", config.GetConfig().GetCompleteConnectionString())
+	if sqlxDB != nil {
+		return sqlxDB
+	}
+
+	sqlxDB, err := sqlx.Open("postgres", config.GetConfig().GetCompleteConnectionString())
 	if err != nil {
 		log.Fatalln("Couldn't connect to data store")
 
 		return nil
 	}
 
-	return db
+	return sqlxDB
 }
 
 // GetSQLDatabase Returns database connection from pool with the default sql package
 func GetSQLDatabase() *sql.DB {
-	db, err := sql.Open("postgres", config.GetConfig().GetCompleteConnectionString())
+	if sqlDB != nil {
+		return sqlDB
+	}
+
+	sqlDB, err := sql.Open("postgres", config.GetConfig().GetCompleteConnectionString())
 	if err != nil {
 		log.Fatalln("Couldn't connect to data store")
 
 		return nil
 	}
 
-	return db
+	return sqlDB
 }
 
 // GetConnection Returns database connection without a database
 func GetConnection() *sqlx.DB {
-	db, err := sqlx.Open("postgres", config.GetConfig().ConnectionString)
+	if sqlxConnection != nil {
+		return sqlxConnection
+	}
+
+	sqlxConnection, err := sqlx.Open("postgres", config.GetConfig().ConnectionString)
 	if err != nil {
 		log.Fatalln("Couldn't connect to data store")
 
 		return nil
 	}
 
-	return db
+	return sqlxConnection
 }
 
 // GetSQLConnection Returns database connection without a database with the default sql package
 func GetSQLConnection() *sql.DB {
-	db, err := sql.Open("postgres", config.GetConfig().ConnectionString)
+	if sqlConnection != nil {
+		return sqlConnection
+	}
+
+	sqlConnection, err := sql.Open("postgres", config.GetConfig().ConnectionString)
 	if err != nil {
 		log.Fatalln("Couldn't connect to data store")
 
 		return nil
 	}
 
-	return db
+	return sqlConnection
 }

--- a/models/datastore.go
+++ b/models/datastore.go
@@ -10,6 +10,9 @@ import (
 	"github.com/antonve/logger-api/config"
 )
 
+const maxOpenConns = 8
+const maxIdleConns = 8
+
 var sqlxDB *sqlx.DB
 var sqlDB *sql.DB
 var sqlxConnection *sqlx.DB
@@ -28,6 +31,9 @@ func GetDatabase() *sqlx.DB {
 		return nil
 	}
 
+	sqlxDB.SetMaxOpenConns(maxOpenConns)
+	sqlxDB.SetMaxIdleConns(maxIdleConns)
+
 	return sqlxDB
 }
 
@@ -43,6 +49,9 @@ func GetSQLDatabase() *sql.DB {
 
 		return nil
 	}
+
+	sqlDB.SetMaxOpenConns(maxOpenConns)
+	sqlDB.SetMaxIdleConns(maxIdleConns)
 
 	return sqlDB
 }
@@ -60,6 +69,9 @@ func GetConnection() *sqlx.DB {
 		return nil
 	}
 
+	sqlxConnection.SetMaxOpenConns(maxOpenConns)
+	sqlxConnection.SetMaxIdleConns(maxIdleConns)
+
 	return sqlxConnection
 }
 
@@ -75,6 +87,9 @@ func GetSQLConnection() *sql.DB {
 
 		return nil
 	}
+
+	sqlConnection.SetMaxOpenConns(maxOpenConns)
+	sqlConnection.SetMaxIdleConns(maxIdleConns)
 
 	return sqlConnection
 }

--- a/models/logs.go
+++ b/models/logs.go
@@ -182,6 +182,7 @@ func (logCollection *LogCollection) GetAllWithFilters(filters map[string]interfa
 	`
 
 	rows, err := db.NamedQuery(query, filters)
+	defer rows.Close()
 
 	if err != nil {
 		return err
@@ -247,6 +248,7 @@ func (logCollection *LogCollection) Add(log *Log) (uint64, error) {
 		RETURNING id
 	`
 	rows, err := db.NamedQuery(query, log)
+	defer rows.Close()
 
 	if err != nil {
 		return 0, err

--- a/models/users.go
+++ b/models/users.go
@@ -183,6 +183,7 @@ func (userCollection *UserCollection) Add(user *User) (uint64, error) {
 		RETURNING id
 	`
 	rows, err := db.NamedQuery(query, user)
+	defer rows.Close()
 
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
## Why

In a different project where I used a similar structure I noticed I was leaking connections in certain requests. Turns out that when you don't call `rows.Close()` when you scan rows, you have a chance of keeping the connection open.

I also realized we're creating a new DB object per request, [instead of reusing the existing one](https://github.com/jmoiron/sqlx/issues/69#issuecomment-47488503). This won't let us use connection pooling effectively.

## What

- [x] Call a deferred `rows.Close()` whenever we scan for rows
- [x] Keep only one instance of our DB connection instead of creating a new one per request
- [x] Set limits for open connections