### PR TITLE
Bump go version on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     docker:
       # specify the version
-      - image: circleci/golang:1.8
+      - image: circleci/golang:1.11
       - image: circleci/postgres:9.6.5-alpine-ram
         environment:
           POSTGRES_USER: ubuntu


### PR DESCRIPTION
## Why

CI is failing since it can't find cURL for the older version... I might need a better way to install cURL so this doesn't fail again in the future.

## What

Bump up the version of Go which also includes a newer Ubuntu container.